### PR TITLE
feat(): add workdir in every image

### DIFF
--- a/1.1.119/Dockerfile
+++ b/1.1.119/Dockerfile
@@ -18,6 +18,8 @@ COPY h2.server.properties /root/.h2.server.properties
 
 EXPOSE 81 1521
 
+WORKDIR /opt/h2-data
+
 CMD java -cp /opt/h2/bin/h2*.jar org.h2.tools.Server \
  	-web -webAllowOthers -webPort 81 \
  	-tcp -tcpAllowOthers -tcpPort 1521 \

--- a/1.4.197/Dockerfile
+++ b/1.4.197/Dockerfile
@@ -18,6 +18,8 @@ COPY h2.server.properties /root/.h2.server.properties
 
 EXPOSE 81 1521
 
+WORKDIR /opt/h2-data
+
 CMD java -cp /opt/h2/bin/h2*.jar org.h2.tools.Server \
  	-web -webAllowOthers -webPort 81 \
  	-tcp -tcpAllowOthers -tcpPort 1521 \

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -20,6 +20,8 @@ COPY h2.server.properties /root/.h2.server.properties
 
 EXPOSE 81 1521
 
+WORKDIR /opt/h2-data
+
 CMD java -cp /opt/h2/bin/h2*.jar org.h2.tools.Server \
  	-web -webAllowOthers -webPort 81 \
  	-tcp -tcpAllowOthers -tcpPort 1521 \


### PR DESCRIPTION
When you are using the command line tools (http://www.h2database.com/html/tutorial.html#command_line_tools), the generated files are saved at the root of the container. By using workdir, we can force it to be made in the `/opt/h2-data` allowing access outside of the container