### PR TITLE
Added 2.0.204 h2 version

### DIFF
--- a/2.0.204/Dockerfile
+++ b/2.0.204/Dockerfile
@@ -1,0 +1,27 @@
+# openjdk:11 image built on Debian GNU/Linux 11 (bullseye)
+FROM openjdk:11
+
+# A merge of:
+#  https://github.com/zhilvis/docker-h2
+#  https://github.com/zilvinasu/h2-dockerfile
+
+MAINTAINER Oscar Fonts <oscar.fonts@geomati.co>
+
+ENV DOWNLOAD https://github.com/h2database/h2database/releases/download/version-2.0.204/h2-2021-12-21.zip
+ENV DATA_DIR /opt/h2-data
+
+RUN mkdir -p ${DATA_DIR}
+RUN curl -L ${DOWNLOAD} -o h2.zip
+RUN unzip h2.zip -d /opt/
+RUN rm h2.zip
+
+COPY h2.server.properties /root/.h2.server.properties
+
+EXPOSE 81 1521
+
+WORKDIR /opt/h2-data
+
+CMD java -cp /opt/h2/bin/h2*.jar org.h2.tools.Server \
+    -web -webAllowOthers -webPort 81 \
+    -tcp -tcpAllowOthers -tcpPort 1521 \
+    -baseDir ${DATA_DIR} ${H2_OPTIONS}

--- a/2.0.204/build.sh
+++ b/2.0.204/build.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+docker build --force-rm=true --no-cache=true -t=h2 .

--- a/2.0.204/h2-data/.gitignore
+++ b/2.0.204/h2-data/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/2.0.204/h2.server.properties
+++ b/2.0.204/h2.server.properties
@@ -1,0 +1,7 @@
+webSSL=false
+webAllowOthers=true
+webPort=81
+0=Generic H2 (Embedded)|org.h2.Driver|jdbc\:h2\:test|sa
+1=Generic H2 (Server) Old Information Schema|org.h2.Driver|jdbc\:h2\:tcp\://localhost\:1521/test;OLD_INFORMATION_SCHEMA\=TRUE|sa
+2=Generic H2 (Server) MariaDB Mode|org.h2.Driver|jdbc\:h2\:tcp\://localhost\:1521/test;MODE\=MariaDB;|sa
+3=Generic H2 (Server)|org.h2.Driver|jdbc\:h2\:tcp\://localhost\:1521/test|sa

--- a/2.0.204/run.sh
+++ b/2.0.204/run.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+docker run -v $PWD/h2-data:/opt/h2-data -d -p 1521:1521 -p 81:81 --name=h2 h2
+docker logs -f h2 2>&1
+#xdg-open http://localhost:81/

--- a/2.0.204/stop.sh
+++ b/2.0.204/stop.sh
@@ -1,0 +1,2 @@
+docker container stop h2
+docker container rm h2

--- a/README.md
+++ b/README.md
@@ -10,12 +10,22 @@ Dockerized H2 database service.
 * H2-DATA location on `/opt/h2-data`
 * A mix of [zhilvis/docker-h2](https://github.com/zhilvis/docker-h2) and [zilvinasu/h2-dockerfile](https://github.com/zilvinasu/h2-dockerfile).
 
+## 2.x.xxx
+
+There are many changes in this major version, including changes in the
+information schema tables. An option has been added to the `h2.server.properties`
+for convenience to allow you to use the information schema from v1 since it is
+difficult to find information about this online (`OLD_INFORMATION_SCHEMA=true`).
+
+Note the use of this property in the constructor of https://github.com/h2database/h2database/blob/master/h2/src/main/org/h2/engine/SessionRemote.java
+
 
 ## Trusted builds
 
 [Automated builds](https://hub.docker.com/r/oscarfonts/h2/) on [docker registry](https://registry.hub.docker.com/):
 
-* [`latest`, `1.4.199` (*1.4.199/Dockerfile*)](https://github.com/oscarfonts/docker-h2/blob/master/1.4.199/Dockerfile)
+* [`2.0.204`, `2.0.204` (*2.0.204/Dockerfile*)](https://github.com/oscarfonts/docker-h2/blob/master/2.0.204/Dockerfile)
+* [`1.4.199`, `1.4.199` (*1.4.199/Dockerfile*)](https://github.com/oscarfonts/docker-h2/blob/master/1.4.199/Dockerfile)
 * [`alpine` (*alpine/Dockerfile*)](https://github.com/oscarfonts/docker-h2/blob/master/alpine/Dockerfile)
 * [`1.1.119` (*1.1.119/Dockerfile*)](https://github.com/oscarfonts/docker-h2/blob/master/1.1.119/Dockerfile)
 * [`geodb` (*geodb/Dockerfile*)](https://github.com/oscarfonts/docker-h2/blob/master/geodb/Dockerfile)


### PR DESCRIPTION
- Bumped openjdk version to 11 LTS. open-jdk:17 image is built on Oracle Linux Server 8.5 which does not have unzip so became scope creep.
- Added additional options to the h2.server.properties to aid other users transitioning from v1 or expecting compatibility with MariaDB.
- Added more explicit docker commands in `stop.sh` (`docker container ....`)

Fixes https://github.com/oscarfonts/docker-h2/issues/14